### PR TITLE
Presidential Escort Gamemode

### DIFF
--- a/PresidentialEscortGamemode/EventsHandler.cs
+++ b/PresidentialEscortGamemode/EventsHandler.cs
@@ -1,0 +1,124 @@
+using System.Runtime.CompilerServices;
+using Smod2.API;
+using Smod2.EventHandlers;
+using Smod2.EventSystem.Events;
+using System.Collections.Generic;
+using Smod2.Events;
+using scp4aiur;
+using UnityEngine;
+
+namespace PresidentialEscortGamemode
+{
+    internal class EventsHandler : IEventHandlerCheckRoundEnd, IEventHandlerRoundStart, IEventHandlerPlayerJoin, IEventHandlerRoundEnd
+    {
+        private readonly PresidentialEscort plugin;
+
+        public EventsHandler(PresidentialEscort plugin) => this.plugin = plugin;
+
+        public void OnPlayerJoin(PlayerJoinEvent ev)
+        {
+            if (PresidentialEscort.enabled)
+            {
+                if (!PresidentialEscort.roundstarted)
+                {
+                    Server server = plugin.pluginManager.Server;
+                    server.Map.ClearBroadcasts();
+                    server.Map.Broadcast(25, "<color=#f8ea56>Presidential Escort</color> gamemode is starting...", false);
+                }
+            }
+        }
+
+        public void OnRoundStart(RoundStartEvent ev)
+        {
+            if (PresidentialEscort.enabled)
+            {
+                PresidentialEscort.roundstarted = true;
+                plugin.pluginManager.Server.Map.ClearBroadcasts();
+                plugin.Info("Presidential Escort Gamemode Started!");
+                List<Player> players = ev.Server.GetPlayers();
+
+                // removes SCPs from player list (used to spawn rest of players)
+                foreach(Player player in players)
+                {
+                    if(player.TeamRole.Team == Smod2.API.Team.SCP)
+                    {
+                        players.Remove(player);
+                    }
+                }
+
+                // chooses and spawns VIP scientist
+                int chosenVIP = new System.Random().Next(players.Count);
+                Player vip = players[chosenVIP];
+                plugin.Info("" + vip.Name + " chosen as the VIP");
+                Timing.Run(Functions.singleton.SpawnVIP(vip));
+                players.Remove(vip);
+
+                // spawn NTF into round
+                foreach (Player player in players)
+                {
+                    Timing.Run(Functions.singleton.SpawnNTF(player));
+                }
+            }
+        }
+
+        public void OnRoundEnd(RoundEndEvent ev)
+        {
+            if (PresidentialEscort.enabled || PresidentialEscort.roundstarted)
+                plugin.Info("Round Ended!");
+                Functions.singleton.EndGamemodeRound();
+        }
+
+        public void OnCheckRoundEnd(CheckRoundEndEvent ev)
+        {
+            if (PresidentialEscort.enabled || PresidentialEscort.roundstarted)
+            {
+                bool vipAlive = false;
+                bool scpAlive = false;
+                bool vipUpgraded = false;
+                bool vipEscaped = false;
+
+                foreach (Player player in ev.Server.GetPlayers())
+                {
+                    if (player.TeamRole.Team == Smod2.API.Team.SCP)
+                    {
+                        scpAlive = true; continue;
+                    }
+
+                    else if (player == PresidentialEscort.vip)
+                    {
+                        vipAlive = true;
+
+                        if (player.TeamRole.Team != Smod2.API.Team.SCIENTIST)
+                        {
+                            vipUpgraded = true;
+                            if (player.HasItem(ItemType.FLASHLIGHT)) vipEscaped = true;
+                        }
+                    }
+                }
+                if (ev.Server.GetPlayers().Count > 1)
+                {
+                    if (vipEscaped)
+                    {
+                        ev.Status = ROUND_END_STATUS.OTHER_VICTORY; Functions.singleton.EndGamemodeRound();
+                    }
+                    else if (vipUpgraded)
+                    {
+                        ev.Status = ROUND_END_STATUS.NO_VICTORY; Functions.singleton.EndGamemodeRound();
+                    }
+                    else if (vipAlive)
+                    {
+                        ev.Status = ROUND_END_STATUS.ON_GOING;
+                    }
+                    else if (scpAlive && !vipAlive)
+                    {
+                        ev.Status = ROUND_END_STATUS.SCP_VICTORY; Functions.singleton.EndGamemodeRound();
+                    }
+                    else
+                    {
+                        ev.Status = ROUND_END_STATUS.NO_VICTORY; Functions.singleton.EndGamemodeRound();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PresidentialEscortGamemode/Functions.cs
+++ b/PresidentialEscortGamemode/Functions.cs
@@ -1,0 +1,81 @@
+using Smod2;
+using UnityEngine;
+using Smod2.API;
+using System.Collections.Generic;
+using System;
+
+namespace PresidentialEscortGamemode
+{
+	public class Functions
+    {
+		public static Functions singleton;
+		public PresidentialEscort PresidentialEscort;
+		public Functions(PresidentialEscort plugin)
+		{
+			this.PresidentialEscort = plugin;
+			Functions.singleton = this;
+		}
+        public void EnableGamemode()
+        {
+            PresidentialEscort.enabled = true;
+            if (!PresidentialEscort.roundstarted)
+            {
+                PresidentialEscort.pluginManager.Server.Map.ClearBroadcasts();
+                PresidentialEscort.pluginManager.Server.Map.Broadcast(25, "<color=#50c878>Zombieland Gamemode</color> is starting..", false);
+            }
+        }
+        public void DisableGamemode()
+        {
+            PresidentialEscort.enabled = false;
+            PresidentialEscort.pluginManager.Server.Map.ClearBroadcasts();
+        }
+        public void EndGamemodeRound()
+        {
+            PresidentialEscort.Info("EndgameRound Function");
+            PresidentialEscort.roundstarted = false;
+            PresidentialEscort.Server.Round.EndRound();
+            PresidentialEscort.pluginManager.CommandManager.CallCommand(null, "SETCONFIG", new string[] {"friendly_fire","false"});
+        }
+
+        public IEnumerable<float> SpawnVIP(Player player)
+        {
+            PresidentialEscort.vip = player;
+            Vector spawn = PresidentialEscort.Server.Map.GetRandomSpawnPoint(Role.CLASSD);
+            player.ChangeRole(Role.SCIENTIST, false, false, true, false);
+            yield return 2;
+            player.Teleport(spawn);
+
+            player.PersonalClearBroadcasts();
+            player.PersonalBroadcast(15, "You are the <color=#f8ea56>VIP</color> Escape the facility with the help of " +
+                "<color=#308ADA>NTF</color> while avoiding the <color=#e83e25>SCPs</color>.", false);
+
+        }
+
+        public IEnumerable<float> SpawnNTF(Player player)
+        {
+            Vector spawn = PresidentialEscort.Server.Map.GetRandomSpawnPoint(Role.CLASSD);
+            player.ChangeRole(Role.NTF_CADET, false, true, false, false);
+            yield return 2;
+            player.Teleport(spawn);
+
+            foreach (Smod2.API.Item item in player.GetInventory())
+            {
+                item.Remove();
+            }
+            
+            player.SetAmmo(AmmoType.DROPPED_5, 500);
+            player.SetAmmo(AmmoType.DROPPED_7, 500);
+            player.SetAmmo(AmmoType.DROPPED_9, 500);
+            player.GiveItem(ItemType.RADIO);
+            player.GiveItem(ItemType.E11_STANDARD_RIFLE);
+            player.GiveItem(ItemType.FLASHBANG);
+            player.GiveItem(ItemType.MEDKIT);
+            player.GiveItem(ItemType.SENIOR_GUARD_KEYCARD);
+            player.GiveItem(ItemType.FRAG_GRENADE);
+
+            player.PersonalClearBroadcasts();
+            player.PersonalBroadcast(15, "You are an <color=#308ADA>NTF Cadet</color>. Work with others to help the " +
+                "<color=#f8ea56>VIP</color> escape and eliminate the <color=#e83e25>SCPs</color>", false);
+        }
+    }
+}

--- a/PresidentialEscortGamemode/PresidentialEscort.cs
+++ b/PresidentialEscortGamemode/PresidentialEscort.cs
@@ -1,0 +1,49 @@
+using Smod2;
+using Smod2.Events;
+using Smod2.Attributes;
+using Smod2.Config;
+using Smod2.API;
+using System.Collections.Generic;
+using scp4aiur;
+
+namespace PresidentialEscortGamemode
+{
+    [PluginDetails(
+        author = "mkrzy",
+        name = "Presidential Escort Gamemode",
+        description = "Scientist (VIP) has to escape from SCPs with help of NTF",
+        id = "mkrzy.gamemode.presidential",
+        version = "1.0",
+        SmodMajor = 3,
+        SmodMinor = 2,
+        SmodRevision = 2
+    )]
+    public class PresidentialEscort : Plugin
+    {
+        internal static PresidentialEscort singleton;
+        public static Player vip = null;
+        
+        public static bool
+            enabled = false,
+            roundstarted = false;
+        
+        public override void OnDisable()
+        {
+            this.Info(this.Details.name + " v." + this.Details.version + " has been disabled.");
+        }
+
+        public override void OnEnable()
+        {
+            singleton = this;
+            this.Info(this.Details.name + " v." + this.Details.version + " has been enabled.");
+        }
+
+        public override void Register()
+        {
+            this.AddEventHandlers(new EventsHandler(this), Priority.Normal);
+            this.AddCommands(new string[] { "presidentialescort", "presidential", "escort", "pe" }, new PresidentialEscortCommand());
+            Timing.Init(this);
+            new Functions(this);
+        }
+    }
+}

--- a/PresidentialEscortGamemode/PresidentialEscortCommand.cs
+++ b/PresidentialEscortGamemode/PresidentialEscortCommand.cs
@@ -1,0 +1,60 @@
+using Smod2.Commands;
+
+namespace PresidentialEscortGamemode
+{
+    class PresidentialEscortCommand : ICommandHandler
+    {
+        public string GetCommandDescription()
+        {
+            return "";
+        }
+
+        public string GetUsage()
+        {
+            return "Presidential Escort Enabled : " + PresidentialEscort.enabled + "\n"+
+                "[presidentialescort / presidential / escort / pe] HELP \n" +
+                "presidential ENABLE \n" +
+                "presidential DISABLE";
+        }
+        public string[] OnCall(ICommandSender sender, string[] args)
+        {
+            if (args.Length > 0)
+            {
+                switch (args[0].ToLower())
+                {
+                    case "help":
+                        return new string[]
+                        {
+                            "Presidential Escort Command List \n"+
+                            "Presidential Escort enable - Enables the Presidential Escort gamemode. \n"+
+                            "Presidential Escort disable - Disables the Presidential Escort gamemode. \n"
+                        };
+                    case "enable":
+                        Functions.singleton.EnableGamemode();
+                        return new string[]
+                        {
+                            "Presidential Escort will be enabled for the next round!"
+                        };
+                    case "disable":
+                        Functions.singleton.DisableGamemode();
+                        return new string[]
+                        {
+                            "Presidential Escort gamemode now disabled."
+                        };
+                    default:
+                        return new string[]
+                        {
+                            GetUsage()
+                        };
+                }
+            }
+            else 
+            {
+                return new string[]
+                {
+                    GetUsage()
+                };
+            }
+        }
+    }
+}

--- a/PresidentialEscortGamemode/README.md
+++ b/PresidentialEscortGamemode/README.md
@@ -1,0 +1,18 @@
+Presidential Escort
+======
+made by mkrzy
+## Description
+A Scientist (VIP) spawns with several NTF in the cell. They need escort the VIP to escape from the facility. 
+There are also some SCPs in the facility. If the VIP dies, SCPs win. If the VIP escapes, humans win.
+
+### Config Settings
+Config option | Config Type | Default Value | Description
+:---: | :---: | :---: | :------
+
+### Commands
+  Command |  |  | Description
+:---: | :---: | :---: | :------
+**Aliases** | **presidentialescort** | **presidential** | **escort**
+presidential Enable | ~~ | ~~ | Enable Presidential Escort for the next round
+presidential Disable | ~~ | ~~ | Disable Presidential Escort this and following rounds
+

--- a/PresidentialEscortGamemode/Timing.cs
+++ b/PresidentialEscortGamemode/Timing.cs
@@ -1,0 +1,144 @@
+﻿// This was made by probe4aiur on GitHub. You can access the latest version here: 
+// https://gist.github.com/probe4aiur/fc74510ea216d30cbb0b6b884c4ba84c
+
+using UnityEngine;
+using Smod2.EventHandlers;
+using Smod2.Events;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace scp4aiur
+{
+	/// <summary>
+	/// Module for easy and efficient frame-based timers
+	/// </summary>
+	internal class Timing : IEventHandlerUpdate, IEventHandlerRoundRestart
+	{
+		private static Action<string> log;
+
+		private static int jobId;
+		private static Dictionary<int, QueueItem> jobs;
+
+		public static void Init(Smod2.Plugin plugin, Priority priority = Priority.Normal)
+		{
+			log = plugin.Error;
+			plugin.AddEventHandlers(new Timing(), priority);
+
+			jobId = int.MinValue;
+			jobs = new Dictionary<int, QueueItem>();
+		}
+
+		/// <summary>
+		/// Queues a job.
+		/// </summary>
+		public static int Run(IEnumerable<float> method, bool persist = false)
+		{
+			int id = jobId++;
+			jobs.Add(id, new QueueItem(method, persist));
+
+			return id;
+		}
+
+		/// <summary>
+		/// Removes a job from the queue.
+		/// </summary>
+		/// <param name="id">ID of the job to remove.</param>
+		public static bool Remove(int id)
+		{
+			return jobs.Remove(id);
+		}
+
+		/// <summary>
+		/// <para>DO NOT USE</para>
+		/// <para>This is an event for Smod2 and as such should not be called by any external code </para>
+		/// </summary>
+		/// <param name="ev"></param>
+		public void OnUpdate(UpdateEvent ev)
+		{
+			int[] removeJobs = jobs.Keys.Where(x => jobs[x].Run()).ToArray();
+
+			foreach (int job in removeJobs)
+			{
+				jobs.Remove(job);
+			}
+		}
+
+		/// <summary>
+		/// <para>DO NOT USE</para>
+		/// <para>This is an event for Smod2 and as such should not be called by any external code </para>
+		/// </summary>
+		/// <param name="ev"></param>
+		public void OnRoundRestart(RoundRestartEvent ev)
+		{
+			int[] removeJobs = jobs.Where(x => !x.Value.RoundPersist).Select(x => x.Key).ToArray();
+
+			foreach (int job in removeJobs)
+			{
+				jobs.Remove(job);
+			}
+		}
+
+		private class QueueItem
+		{
+			private readonly IEnumerator<float> timer;
+			private int waitFrames;
+			private float waitTime;
+
+			public bool RoundPersist { get; }
+
+			public QueueItem(IEnumerable<float> timer, bool persist)
+			{
+				this.timer = timer.GetEnumerator();
+				RoundPersist = persist;
+			}
+
+			public bool Run()
+			{
+				try
+				{
+					if (waitFrames < 1)
+					{
+						if (waitTime <= 0)
+						{
+							if (!timer.MoveNext())
+							{
+								return true;
+							}
+
+							if (timer.Current > 0)
+							{
+								waitTime += timer.Current;
+							}
+							else
+							{
+								waitFrames = (int)-timer.Current;
+							}
+						}
+						else
+						{
+							waitTime -= Time.deltaTime;
+						}
+					}
+					else
+					{
+						waitFrames--;
+					}
+
+					return false;
+				}
+				catch (Exception e)
+				{
+					log($"Exception was thrown by job:\n{e}");
+					return true;
+				}
+			}
+		}
+
+        internal static void Run(object spawnVIP)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
A Scientist (VIP) spawns with several NTF in the cell. They need escort the VIP to escape from the facility. There are also some SCPs in the facility. If the VIP dies, SCPs win. If the VIP escapes, humans win.

NOTE (because I couldn't find another way to test if the scientist has escaped):
The VIP win condition (aka scientist escapes), is currently based on if the **original** scientist (VIP) is no longer a scientist and possesses a flashlight. The reasoning behind this is 914 could cause faulty win conditions, such as if someone were to turn into a scientist, or if the scientist were to upgrade to an NTF. Because of this possibility, original NTF will spawn without flashlights, so when the scientist escapes and respawns as an upgraded class, they will have a flashlight in their inventory. If the scientist is upgraded and without a flashlight (possible via 914), the round ends with no victory.